### PR TITLE
rjd_strbuf crash fix:

### DIFF
--- a/rjd.h
+++ b/rjd.h
@@ -4620,9 +4620,8 @@ void rjd_strbuf_appendl(struct rjd_strbuf* buf, const char* format, uint32_t len
 	uint32_t capacity = buf->heap ? rjd_array_capacity(buf->heap) : RJD_STRBUF_STATIC_SIZE;
 	uint32_t remaining = capacity - buf->length;
 
-	if (remaining < length) {
+	if (remaining < length + 1) {
 		rjd_strbuf_grow(buf, length);
-		remaining = rjd_array_capacity(buf->heap) - buf->length;
 	}
 
 	char* str = buf->heap ? buf->heap : buf->stack;
@@ -4655,6 +4654,8 @@ static void rjd_strbuf_grow(struct rjd_strbuf* buf, uint32_t format_length)
 		rjd_array_resize(buf->heap, next);
 
 		strcpy(buf->heap, buf->stack);
+	} else {
+		rjd_array_resize(buf->heap, next);
 	}
 }
 

--- a/rjd_strbuf.h
+++ b/rjd_strbuf.h
@@ -115,9 +115,8 @@ void rjd_strbuf_appendl(struct rjd_strbuf* buf, const char* format, uint32_t len
 	uint32_t capacity = buf->heap ? rjd_array_capacity(buf->heap) : RJD_STRBUF_STATIC_SIZE;
 	uint32_t remaining = capacity - buf->length;
 
-	if (remaining < length) {
+	if (remaining < length + 1) {
 		rjd_strbuf_grow(buf, length);
-		remaining = rjd_array_capacity(buf->heap) - buf->length;
 	}
 
 	char* str = buf->heap ? buf->heap : buf->stack;
@@ -150,6 +149,8 @@ static void rjd_strbuf_grow(struct rjd_strbuf* buf, uint32_t format_length)
 		rjd_array_resize(buf->heap, next);
 
 		strcpy(buf->heap, buf->stack);
+	} else {
+		rjd_array_resize(buf->heap, next);
 	}
 }
 

--- a/tests.c
+++ b/tests.c
@@ -1521,6 +1521,12 @@ void test_strbuf(void)
 	rjd_strbuf_append(&builder, "3");
 	expect_str("123456789012345678901234567890123", rjd_strbuf_str(&builder));
 
+	rjd_strbuf_append(&builder, "123456789012345678901234567890");
+	rjd_strbuf_append(&builder, "123456789012345678901234567890");
+	rjd_strbuf_append(&builder, "123456789012345678901234567890");
+	expect_str("12345678901234567890123456789012312345678901234567890123456789012345"
+				"6789012345678901234567890123456789012345678901234567890", rjd_strbuf_str(&builder));
+
 	rjd_strbuf_free(&builder);
 
 	// append substring


### PR DESCRIPTION
* missed resizing the heap buffer after it was already allocated